### PR TITLE
Gm pme2

### DIFF
--- a/platforms/reference/src/MBPolReferenceElectrostaticsForce.cpp
+++ b/platforms/reference/src/MBPolReferenceElectrostaticsForce.cpp
@@ -3263,7 +3263,7 @@ RealOpenMM MBPolReferencePmeElectrostaticsForce::calculatePmeDirectElectrostatic
 			      	  + glip1 * (1 - scale5CD)   // charge - inddip 
 				  + scip2 * (1 - scale5DD) ) // inddip - inddip
 	    //FIXME Should there be an rr7 in front of sci3*scip4????!?
-	                    - (sci3*scip4+scip3*sci4)
+	                  - rr7 * (sci3*scip4+scip3*sci4)
 			                  * (1 - scale7DD)   // inddip - inddip
 			   );
 


### PR DESCRIPTION
Cleaned up the electrostatic pair interaction functions. Fixed bug in missing rr7 term for PME force.
